### PR TITLE
Markdown tweak to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@
 
       return this;
     }
-  ```
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
The formatting went awry on the [npm package page](https://www.npmjs.com/package/mofo-style) after this code block.

I think it's caused by the indent of the ```