### PR TITLE
allow console

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -67,6 +67,10 @@ rules: # http://eslint.org/docs/rules
 
   prefer-arrow-callback: [1]
 
+  # Overrides to `eslint:recommended` rule set
+
+  no-console: [0]
+
 extends: "eslint:recommended"
 
 ecmaFeatures:


### PR DESCRIPTION
Apparently setting your environment to node doesn't override `no-console`, which is odd, but I think we should disable the rule for that reason.