### PR TITLE
adding global strict

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -37,7 +37,7 @@ rules: # http://eslint.org/docs/rules
 
   # Strict Mode
 
-  strict: [2, "never"]
+  strict: [2, "global"]
 
   # Variables
 


### PR DESCRIPTION
So, admittedly I'm reversing course on this a bit, but I realized today that without `"use strict";` we can't use `let` and `const` in the global scope of a node script. :rage1: 

One global declaration of `"use strict";` isn't too pollute-y for my tastes.